### PR TITLE
Fix timezone

### DIFF
--- a/src/test/java/testsuite/regression/StatementRegressionTest.java
+++ b/src/test/java/testsuite/regression/StatementRegressionTest.java
@@ -4364,7 +4364,7 @@ public class StatementRegressionTest extends BaseTestCase {
 			assertEquals(earlier, timestampSeconds1);
 
 			SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm z");
-			sdf.setTimeZone(TimeZone.getTimeZone("America/New York"));
+			sdf.setTimeZone(TimeZone.getTimeZone("America/New_York"));
 			System.out.println(sdf.format(ts2));
 			System.out.println(sdf.format(ts1));
 		} finally {


### PR DESCRIPTION
"America/New York" is not a valid timezone, and so GMT will be used instead. Needs underscore instead of space.